### PR TITLE
fixed layout and hover state of image links on homepage

### DIFF
--- a/src/Home.tsx
+++ b/src/Home.tsx
@@ -7,19 +7,19 @@ import HomePageHeader from "./components/HomePageHeader";
 import { useScrollableAnimation } from "./useScrollableAnimation";
 
 const Home = () => {
-    const { isDesktop } = useMediaQueryContext();
-    const animationParams = useScrollableAnimation();
-    return (
-        <>
-            <HomePageHeader {...animationParams} />
-            {isDesktop ? (
-                <DesktopMainLogos {...animationParams} />
-            ) : (
-                <MainLogos {...animationParams} />
-            )}
-            <MainMenuImageLinks />
-        </>
-    );
+  const { isDesktop } = useMediaQueryContext();
+  const animationParams = useScrollableAnimation();
+  return (
+    <>
+      <HomePageHeader {...animationParams} />
+      {isDesktop ? (
+        <DesktopMainLogos {...animationParams} />
+      ) : (
+        <MainLogos {...animationParams} />
+      )}
+      <MainMenuImageLinks />
+    </>
+  );
 };
 
 export default Home;

--- a/src/components/ImageLink.tsx
+++ b/src/components/ImageLink.tsx
@@ -1,33 +1,28 @@
 import React from "react";
 import styled from "styled-components";
 
-const SUPPORTED_HEIGHT = 1366;
-
 const Container = styled.a`
-  position: relative;
   display: flex;
-  width: 48%;
-  height: 15%;
   flex-direction: column;
-  justify-content: space-between;
-`;
-
-const Image = styled.img`
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-`;
-
-const TextContainer = styled.div`
-  position: absolute;
-  bottom: 0;
-  box-sizing: border-box;
-  padding: 20px;
-  width: 100%;
   background-color: #002fa7;
   &:hover {
     background-color: #ff0d70;
   }
+  align-items: stretch;
+  text-decoration: none;
+  min-width: 384px;
+  width: 48%;
+`;
+
+const Image = styled.img`
+  width: 100%;
+  aspect-ratio: 1 / 1;
+  object-fit: cover;
+`;
+
+const TextContainer = styled.div`
+  box-sizing: border-box;
+  padding: 20px;
 `;
 
 const Text = styled.div`

--- a/src/components/MobileImageLink.tsx
+++ b/src/components/MobileImageLink.tsx
@@ -1,36 +1,40 @@
 import React from "react";
 import styled from "styled-components";
 
-const Container = styled.div`
-    display: flex;
-    flex-direction: column;
-    align-items: stretch;
-    width: 100vw;
-    margin-bottom: 5vw;
+const Container = styled.a`
+  display: flex;
+  flex-direction: column;
+  background-color: #002fa7;
+  &:hover {
+    background-color: #ff0d70;
+  }
+  align-items: stretch;
+  text-decoration: none;
+  min-width: 384px;
+  width: 100vw;
+  margin-bottom: 5vw;
 `;
 
 const Image = styled.img`
-    width: 100vw;
-    max-height: 100vw;
-    object-fit: cover;
+  width: 100vw;
+  aspect-ratio: 1 / 1;
+  object-fit: cover;
 `;
 
-const Text = styled.a`
-    box-sizing: border-box;
-    background-color: #002fa7;
-    color: white;
-    width: 100%;
-    text-decoration: none;
-    padding: 5vw;
-    font-size: 6vw;
-    line-height: 8vw;
+const Text = styled.div`
+  box-sizing: border-box;
+  color: white;
+  width: 100%;
+  padding: 5vw;
+  font-size: 6vw;
+  line-height: 8vw;
 `;
 
 export const MobileImageLink = ({ img, text, linksTo }: ImageLinkProps) => {
-    return (
-        <Container>
-            <Image src={`assets/${img}`} />
-            <Text href={`${linksTo}.html`}>{text}</Text>
-        </Container>
-    );
+  return (
+    <Container href={`${linksTo}.html`}>
+      <Image src={`assets/${img}`} />
+      <Text>{text}</Text>
+    </Container>
+  );
 };


### PR DESCRIPTION
- images are now square while filling up the two-column space
- basis width of 48% plus min-width of 384px helps switch to single column with plenty of margin when screen is smaller
- mobile devices still get full screen width for each image
- the separate mobile components also got appropriate changes
- hovering over whole image now also changes background color for text below the image
- got rid of messy position relative and absolute
- an odd number of images still results in a nice centered image of the same size as the others for the last one (two-column mode)